### PR TITLE
fasterxml jackson version bump

### DIFF
--- a/pom.xml.in
+++ b/pom.xml.in
@@ -58,7 +58,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<commons-lang.version>3.7</commons-lang.version>
-		<jackson.version>2.10.3</jackson.version>
+		<jackson.version>2.12.1</jackson.version>
 		<junit.version>4.12</junit.version>
 		<slf4j.version>1.7.22</slf4j.version>
 		<mockito.version>2.20.0</mockito.version>

--- a/vdsm-jsonrpc-java.spec.in
+++ b/vdsm-jsonrpc-java.spec.in
@@ -41,9 +41,9 @@ BuildArch:	noarch
 
 BuildRequires:  apache-commons-lang3
 BuildRequires:	gcc
-BuildRequires:	jackson-annotations >= 2.9.0
-BuildRequires:	jackson-core >= 2.9.0
-BuildRequires:	jackson-databind >= 2.9.0
+BuildRequires:	jackson-annotations >= 2.10.0
+BuildRequires:	jackson-core >= 2.10.0
+BuildRequires:	jackson-databind >= 2.10.0
 BuildRequires:	java-11-openjdk-devel >= 11.0.4
 BuildRequires:	javapackages-tools
 BuildRequires:	slf4j >= 1.7.0


### PR DESCRIPTION
Upgrade from 2.10 to 2.12

Jackson 2.12 is used by ovirt engine. Leaving spec requirement to >= 2.10 because of backward compatibility

Signed-off-by: Artur Socha <asocha@redhat.com>