### PR TITLE
spec: fix bogus date in changelog

### DIFF
--- a/vdsm-jsonrpc-java.spec.in
+++ b/vdsm-jsonrpc-java.spec.in
@@ -112,10 +112,10 @@ export JAVA_HOME="%{_java_jdk_home}"
 %files javadoc -f .mfiles-javadoc
 
 %changelog
-* Fri Dec 20 2021 Artur Socha <asocha@redhat.com> 1.7.1
+* Mon Dec 20 2021 Artur Socha <asocha@redhat.com> 1.7.1
 - Jackson upgrade to 2.12.1
 
-* Fri Dec 20 2021 Artur Socha <asocha@redhat.com> 1.7.0
+* Mon Dec 20 2021 Artur Socha <asocha@redhat.com> 1.7.0
 - Batch calls support removed
 - Migrated to GitHub and GitHub Actions
 - Apache commons lang bumped to lang3


### PR DESCRIPTION
Fixes:
```
rpmbuild -bs vdsm-jsonrpc-java.spec
warning: bogus date in %changelog: Fri Dec 20 2021 Artur Socha <asocha@redhat.com> 1.7.1
warning: bogus date in %changelog: Fri Dec 20 2021 Artur Socha <asocha@redhat.com> 1.7.0
Wrote: /home/sbonazzo/rpmbuild/SRPMS/vdsm-jsonrpc-java-1.7.1-1.el8.src.rpm

```