### PR TITLE
mark the copr make_srpm git dir as safe (git 2.35.2 security fix)

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,4 +1,4 @@
-.PHONY: installdeps srpm
+.PHONY: installdeps srpm git-safe
 
 installdeps:
 	dnf -y install \
@@ -23,7 +23,12 @@ installdeps:
 		slf4j-jdk14 \
 		sed
 
-srpm: installdeps
+# explicity mark the copr generated git repo directory (which is done prior to the mock
+# # call to the make_srpm and will be the current pwd) as safe for git commands
+git-safe:
+	git config --global --add safe.directory "$(shell pwd)"
+
+srpm: installdeps git-safe
 	$(eval SUFFIX=$(shell sh -c " echo '.$$(date -u +%Y%m%d%H%M%S).git$$(git rev-parse --short HEAD)'"))
 	# changing the spec file as passing -D won't preserve the suffix when rebuilding in mock
 	sed "s:%{?release_suffix}:${SUFFIX}:" -i vdsm-jsonrpc-java.spec.in


### PR DESCRIPTION
See [CVE-2022-24765](https://github.blog/2022-04-12-git-security-vulnerability-announced/)

Signed-off-by: Artur Socha <asocha@redhat.com>
