### PR TITLE
Remove release suffix for copr builds

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -31,6 +31,6 @@ git-safe:
 srpm: installdeps git-safe
 	# $(eval SUFFIX=$(shell sh -c " echo '.$$(date -u +%Y%m%d%H%M%S).git$$(git rev-parse --short HEAD)'"))
 	# changing the spec file as passing -D won't preserve the suffix when rebuilding in mock
-	sed "s:%{?release_suffix}:${SUFFIX}:" -i vdsm-jsonrpc-java.spec.in
+	#sed "s:%{?release_suffix}:${SUFFIX}:" -i vdsm-jsonrpc-java.spec.in
 	.automation/build-srpm.sh
 	cp rpmbuild/SRPMS/$(shell sh -c "basename '$(spec)'|cut -f1 -d.")*.src.rpm $(outdir)


### PR DESCRIPTION
Signed-off-by: Artur Socha <asocha@redhat.com>
