### PR TITLE
Post release.

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -17,7 +17,7 @@ make clean
 # build tarballs
 make dist
 
-# SUFFIX=".$(date -u +%Y%m%d%H%M%S).git$(git rev-parse --short HEAD)"
+SUFFIX=".$(date -u +%Y%m%d%H%M%S).git$(git rev-parse --short HEAD)"
 
 # Build SRPMs
 rpmbuild \

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -29,8 +29,8 @@ git-safe:
 	git config --global --add safe.directory "$(shell pwd)"
 
 srpm: installdeps git-safe
-	# $(eval SUFFIX=$(shell sh -c " echo '.$$(date -u +%Y%m%d%H%M%S).git$$(git rev-parse --short HEAD)'"))
+	$(eval SUFFIX=$(shell sh -c " echo '.$$(date -u +%Y%m%d%H%M%S).git$$(git rev-parse --short HEAD)'"))
 	# changing the spec file as passing -D won't preserve the suffix when rebuilding in mock
-	#sed "s:%{?release_suffix}:${SUFFIX}:" -i vdsm-jsonrpc-java.spec.in
+	sed "s:%{?release_suffix}:${SUFFIX}:" -i vdsm-jsonrpc-java.spec.in
 	.automation/build-srpm.sh
 	cp rpmbuild/SRPMS/$(shell sh -c "basename '$(spec)'|cut -f1 -d.")*.src.rpm $(outdir)


### PR DESCRIPTION
Restore git suffixes for copr and gh builds.

Signed-off-by: Artur Socha <asocha@redhat.com>
