### PR TITLE
Bump fasterxml jackson to avoid CVEs

### DIFF
--- a/pom.xml.in
+++ b/pom.xml.in
@@ -58,7 +58,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<commons-lang.version>3.7</commons-lang.version>
-		<jackson.version>2.12.1</jackson.version>
+		<jackson.version>2.12.7</jackson.version>
 		<junit.version>4.12</junit.version>
 		<slf4j.version>1.7.22</slf4j.version>
 		<mockito.version>2.20.0</mockito.version>


### PR DESCRIPTION
Sonatype reports [1] that currently used version do have CVEs marked as high[2][3]. Bumping minor
version to get rid of it.

[1] https://sbom.lift.sonatype.com/report/T1-a0368c8f29fdaa555824-86f3333f31f08-1658829333-6e6c305c50524115b94d30624caabdb0
[2] https://ossindex.sonatype.org/vulnerability/CVE-2020-36518?component-type=maven&component-name=com.fasterxml.jackson.core%2Fjackson-databind&utm_source=ossindex-client&utm_medium=integration&utm_content=1.7.0
[3] https://ossindex.sonatype.org/vulnerability/sonatype-2021-4682?component-type=maven&component-name=com.fasterxml.jackson.core%2Fjackson-databind&utm_source=ossindex-client&utm_medium=integration&utm_content=1.7.0

Signed-off-by: Artur Socha <asocha@redhat.com>
