### PR TITLE
Disconnect the session after SSL handshake issue

### DIFF
--- a/client/src/main/java/org/ovirt/vdsm/jsonrpc/client/reactors/ReactorClient.java
+++ b/client/src/main/java/org/ovirt/vdsm/jsonrpc/client/reactors/ReactorClient.java
@@ -141,7 +141,7 @@ public abstract class ReactorClient {
             this.closing.set(false);
             clean();
             postConnect(getPostConnectCallback());
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (ClientConnectionException | InterruptedException | ExecutionException e) {
             logException(log, "Exception during connection", e);
             final String message = "Connection issue " + ExceptionUtils.getRootCause(e).getMessage();
             scheduleClose(message);


### PR DESCRIPTION
When the handshake check that is added in PR #17 fails, then a ClientConnectionException is thrown, and passed up to the client in ovirt-engine.
But as the connection is in some invalid state, but not disconnected, it for example causes there are no heartbeats anymore.

This fix also closes the connection when there is some ClientConnectionException in the postConnect stage.

This should fix #27