### PR TITLE
ci: fix snapshot publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,4 +97,7 @@ jobs:
             }]
 
       - name: Publish snapshot
-        run: mvn --batch-mode -DskipTests deploy
+        run: |
+          ./autogen.sh
+          ./configure
+          mvn --batch-mode -DskipTests deploy


### PR DESCRIPTION
Autogen and configure need to run to parse the `pom.xml.in` files before running maven.