### PR TITLE
ci: update argline for build and ci flow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
 
   publish-snapshot:
     needs: build-rpms
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     name: Publish snapshot to maven central
 

--- a/pom.xml.in
+++ b/pom.xml.in
@@ -119,7 +119,10 @@
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>${maven-surefire-plugin.version}</version>
 					<configuration>
-						<argLine>--illegal-access=permit</argLine>
+						<argLine>
+							--add-opens java.base/java.lang=ALL-UNNAMED
+							--add-opens java.base/java.lang.reflect=ALL-UNNAMED
+						</argLine>
 						<parallel>all</parallel>
 						<threadCount>4</threadCount>
 						<perCoreThreadCount>true</perCoreThreadCount>


### PR DESCRIPTION
- alter deprecated argline to a functional alternative from JDK 17 and onwards
- only publish the snapshot for actions on the master, not on branches